### PR TITLE
Fix bug JDK-8218677

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,27 @@
 
+Welcome to Landmark's JDK fork
+==============================
+The branch *hg* is copied from the official openjdk mercurial repo [jdk-updates/jdk11u](https://hg.openjdk.java.net/jdk-updates/jdk11u).
+The branch *dsg* is a forked version with Landmark fixes.
+
+If you want to update jdk to a newer version:
+
+* checkout branch *hg* of this repo
+* in a separated folder clone the openjdk hg repo and checkout a required tag.
+* copy all files from the hg repo (except .hg and .hgignore) and paste to the git repo folder, choose yes to overwrite files.
+* commit changes to git (branch *hg*)
+* add a version tag
+* push commit to origin/hg
+* merge changed from *hg* to *dsg*, resolve conflicts, test and push to *dsg* branch
+
+If you want to make further changes in the fork:
+
+* checkout branch *dsg* of this repo
+* create a fix branch from *dsg* branch
+* make changes, test, commit and push
+* create a pull request to merge your fix branch to *dsg*
+
+
 Welcome to the JDK!
 ===================
 

--- a/src/java.desktop/unix/classes/sun/awt/X11/XEmbeddedFramePeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XEmbeddedFramePeer.java
@@ -146,18 +146,15 @@ public class XEmbeddedFramePeer extends XFramePeer {
         // fix for 5063031
         // if we use super.handleConfigureNotifyEvent() we would get wrong
         // size and position because embedded frame really is NOT a decorated one
-        checkIfOnNewScreen(toGlobal(new Rectangle(scaleDown(xe.get_x()),
-                                                  scaleDown(xe.get_y()),
-                                                  scaleDown(xe.get_width()),
-                                                  scaleDown(xe.get_height()))));
+        checkIfOnNewScreen(toGlobal(new Rectangle(xe.get_x(), xe.get_y(), xe.get_width(), xe.get_height())));
 
         Rectangle oldBounds = getBounds();
 
         synchronized (getStateLock()) {
-            x = scaleDown(xe.get_x());
-            y = scaleDown(xe.get_y());
-            width = scaleDown(xe.get_width());
-            height = scaleDown(xe.get_height());
+            x = xe.get_x();
+            y = xe.get_y();
+            width = xe.get_width();
+            height = xe.get_height();
 
             dimensions.setClientSize(width, height);
             dimensions.setLocation(x, y);


### PR DESCRIPTION
Bug: https://bugs.openjdk.java.net/browse/JDK-8218677

In an SWT application with embedded AWT frame (using SWT_AWT) running with HiDPI scaling (say, GDK_SCALE=2) 
if you resize the container, the size of an embedded AWT frame jumps between the correct and half size. 

The "bad" resize comes from XLibWrapper, when both SWT and Swing are scaled, the coordinates in XEvent should not be scaled down.

Tested on a sandbox app and on DSG