### PR TITLE
JDK-8199937 : Drag-n-drop eventually fails to drop when dragging over an embedded frame

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XDnDDropTargetProtocol.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XDnDDropTargetProtocol.java
@@ -427,8 +427,9 @@ class XDnDDropTargetProtocol extends XDropTargetProtocol {
         boolean track = true;
         long[] formats = null;
 
+		// jdk bug - https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8199937
         if (getSourceWindow() != 0) {
-            return false;
+            cleanup();
         }
 
         if (!(XToolkit.windowToXWindow(xclient.get_window()) instanceof XWindow)


### PR DESCRIPTION
jdk bug - https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8199937

**"Description:"**

DropTargetListner methods are not triggered for the traget frame while dragging an item using GTK API over an embedded AWT frame to a normal AWT frame.

As per description, the issue is reproducible with JDK 8u161 and JDK 10 when checked in RHEL 7.3 (64-bit). 
The bug is well reproducible when mouse speed is high at the moment of entering the target frame.

Analysis shows that XdndEnter message for dialog may arrive before the XdndLeave for the embedded frame. In that case the check in XDnDDropTargetProtocol#processXdndEnter just ignores the XdndEnter and the subsequent event will be ignored as well.

The suggested fix is replace the check in processXdndEnter
=======================
if (this.getSourceWindow() != 0L) {
   return false;
}

by

if (this.getSourceWindow() != 0L) {
   cleanup();
}  // do not return, proceed
=======================
The provided test case is incomplete. Therefore written back to the submitter to provide the complete test to verify this issue in-depth.